### PR TITLE
Toggle between percentage and absolute values

### DIFF
--- a/src/cornelius.js
+++ b/src/cornelius.js
@@ -38,6 +38,8 @@
 
         rawNumberOnHover: true,
 
+        displayAbsoluteValue: false,
+
         initialIntervalNumber: 1,
 
         classPrefix: 'cornelius-',
@@ -192,7 +194,7 @@
                         floatValue = value && parseFloat(value),
                         highestLevel = null;
 
-                    var classNames = ['percentage'];
+                    var classNames = [config.displayAbsoluteValue ? 'absolute' : 'percentage'];
 
                     for (var level in levels) {
                         if (floatValue >= levels[level][0] && floatValue < levels[level][1]) {
@@ -222,14 +224,14 @@
                     if (j > config.maxColumns) break;
 
                     var value = row[j],
-                        cellValue = j === 0 ? value : formatPercentage(value, baseValue),
+                        cellValue = j === 0 || config.displayAbsoluteValue ? value : formatPercentage(value, baseValue),
                         opts = {};
 
                         if (!isEmpty(cellValue)) {
                             opts = {
                                 text: cellValue,
                                 title: j > 0 && config.rawNumberOnHover ? value : null,
-                                className: j === 0 ? 'people' : classNameFor(cellValue)
+                                className: j === 0 ? 'people' : classNameFor(formatPercentage(value, baseValue))
                             };
                         } else if (config.drawEmptyCells) {
                             opts = { text: '-', className: 'empty' };

--- a/src/cornelius.js
+++ b/src/cornelius.js
@@ -224,14 +224,15 @@
                     if (j > config.maxColumns) break;
 
                     var value = row[j],
-                        cellValue = j === 0 || config.displayAbsoluteValue ? value : formatPercentage(value, baseValue),
+                        formattedPercentage = formatPercentage(value, baseValue),
+                        cellValue = j === 0 || config.displayAbsoluteValue ? value : formattedPercentage,
                         opts = {};
 
                         if (!isEmpty(cellValue)) {
                             opts = {
                                 text: cellValue,
                                 title: j > 0 && config.rawNumberOnHover ? value : null,
-                                className: j === 0 ? 'people' : classNameFor(formatPercentage(value, baseValue))
+                                className: j === 0 ? 'people' : classNameFor(formattedPercentage)
                             };
                         } else if (config.drawEmptyCells) {
                             opts = { text: '-', className: 'empty' };

--- a/test/specs.js
+++ b/test/specs.js
@@ -140,22 +140,14 @@ describe('Cornelius', function() {
 
   describe("Absolute numbers", function() {
 
-    var expectedValues = [
-      [1000,700,600,500,400,70,20],
-      [1200,549,336,221,122,115],
-      [900,882,250,32,18],
-      [500,379,254,314],
-      [400,256,120],
-      [600,340]
-    ];
-
     it("renders the absolute values", function() {
-        draw({displayAbsoluteValue: true});
+      draw({displayAbsoluteValue: true});
       $container.find('tr:not(:first)').each(function(i, el){
         var values = $(el).find('.cornelius-absolute').map(function() { return this.textContent; }).get();
-        values.should.deep.equal(expectedValues[i]);
+        values.should.deep.equal(data[i]);
       });
     });
+
   });
 
   describe("Options", function() {

--- a/test/specs.js
+++ b/test/specs.js
@@ -136,7 +136,26 @@ describe('Cornelius', function() {
         values.should.deep.equal(expectedValues[i]);
       });
     });
+  });
 
+  describe("Absolute numbers", function() {
+
+    var expectedValues = [
+      [1000,700,600,500,400,70,20],
+      [1200,549,336,221,122,115],
+      [900,882,250,32,18],
+      [500,379,254,314],
+      [400,256,120],
+      [600,340]
+    ];
+
+    it("renders the absolute values", function() {
+        draw({displayAbsoluteValue: true});
+      $container.find('tr:not(:first)').each(function(i, el){
+        var values = $(el).find('.cornelius-absolute').map(function() { return this.textContent; }).get();
+        values.should.deep.equal(expectedValues[i]);
+      });
+    });
   });
 
   describe("Options", function() {


### PR DESCRIPTION
Hi, I have made a new property which makes it possible to toggle between "Absolute" and "Percentage". As I am working with your cohort library I needed this function, but it wasn't been implemented. 

I created a dirty hack by looping at at the table after it was rendered. That's not really the best option, so I decided to create a better "fix". Could you please merge this with your master. 

Please don't blame if the test case isn't working. I have never worked with PhantomJS/Mocha before and I don't have that installed right now. 
At least I tried to :smile: 

Thanks!